### PR TITLE
Adding thread for processing large playlists

### DIFF
--- a/skill/app.py
+++ b/skill/app.py
@@ -489,8 +489,8 @@ class NaviSonicPlayPlaylist(AbstractRequestHandler):
         else:
             song_id_list = connection.build_song_list_from_playlist(playlist_id)
             play_queue.clear()
-            controller.enqueue_songs(connection, play_queue, [song_id_list[0]])
-            process = Process(target=queueWorkerThread, args=(connection, play_queue, song_id_list[1:]))
+            controller.enqueue_songs(connection, play_queue, [song_id_list[0], song_id_list[1]])
+            process = Process(target=queueWorkerThread, args=(connection, play_queue, song_id_list[2:]))
             process.start()
             speech = 'Playing playlist ' + str(playlist.value)
             logger.info(speech)
@@ -504,6 +504,7 @@ class NaviSonicPlayPlaylist(AbstractRequestHandler):
 def queueWorkerThread(connection, play_queue, song_id_list):
     logger.debug('In playlist processing thread!')
     controller.enqueue_songs(connection, play_queue, song_id_list)
+    play_queue.sync()
     logger.debug('Finished playlist processing!')
 
 class NaviSonicPlayMusicByGenre(AbstractRequestHandler):

--- a/skill/app.py
+++ b/skill/app.py
@@ -3,6 +3,9 @@ import logging
 import os
 import random
 import sys
+from multiprocessing import Process, Manager
+from multiprocessing.managers import BaseManager
+
 
 from ask_sdk_core.skill_builder import SkillBuilder
 from ask_sdk_core.dispatch_components import AbstractRequestHandler, AbstractRequestInterceptor, AbstractResponseInterceptor
@@ -173,7 +176,10 @@ if 'NAVI_DEBUG' in os.environ:
         logger.warning('Log level set to WARNING')
 
 # Create a queue
-play_queue = queue.MediaQueue()
+BaseManager.register('MediaQueue', queue.MediaQueue)
+manager = BaseManager()
+manager.start()
+play_queue = manager.MediaQueue()
 logger.debug('MediaQueue object created...')
 
 # Connect to Navidrome
@@ -483,8 +489,9 @@ class NaviSonicPlayPlaylist(AbstractRequestHandler):
         else:
             song_id_list = connection.build_song_list_from_playlist(playlist_id)
             play_queue.clear()
-            controller.enqueue_songs(connection, play_queue, song_id_list)
-
+            controller.enqueue_songs(connection, play_queue, [song_id_list[0]])
+            process = Process(target=queueWorkerThread, args=(connection, play_queue, song_id_list[1:]))
+            process.start()
             speech = 'Playing playlist ' + str(playlist.value)
             logger.info(speech)
             card = {'title': 'AskNavidrome',
@@ -494,6 +501,10 @@ class NaviSonicPlayPlaylist(AbstractRequestHandler):
 
             return controller.start_playback('play', speech, card, track_details, handler_input)
 
+def queueWorkerThread(connection, play_queue, song_id_list):
+    logger.debug('In playlist processing thread!')
+    controller.enqueue_songs(connection, play_queue, song_id_list)
+    logger.debug('Finished playlist processing!')
 
 class NaviSonicPlayMusicByGenre(AbstractRequestHandler):
     """ Play songs from the given genere


### PR DESCRIPTION
So I ran into a problem many people had around a playlist being too big to process within the timeout of the Alexa skill. I got around this by returning the first item in the playlist then spinning up a new process to crunch on the rest in the background.

Tested with a playlist of 170+ songs. I was able to get it to start playing the first song then I was able to tell it to go to the next song. Though would like some other 👀 on this as well.

Not sure if there is a procedure for this repo or not around pull requests. Let me know if anything needs to change or if anyone has thoughts!

Related Issues:
https://github.com/rosskouk/asknavidrome/issues/55
https://github.com/rosskouk/asknavidrome/issues/38
