### PR TITLE
Generic play intent via fuzzy matching + robustness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__
+.env
 env
+.venv
 sphinx/_build/*
 !sphinx/_build/.gitkeep
 sphinx/resources/*.bkp
@@ -7,3 +9,5 @@ sphinx/resources/*.dtmp
 asknavidrome.log
 test.py
 NOTES.md
+uv.lock
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 __pycache__
-.env
 env
 .venv
 sphinx/_build/*

--- a/alexa.json
+++ b/alexa.json
@@ -32,6 +32,18 @@
                     "samples": []
                 },
                 {
+                    "name": "NaviSonicPlay",
+                    "slots": [
+                        {
+                            "name": "query",
+                            "type": "AMAZON.SearchQuery"
+                        }
+                    ],
+                    "samples": [
+                        "play {query}"
+                    ]
+                },
+                {
                     "name": "NaviSonicPlayMusicByArtist",
                     "slots": [
                         {

--- a/asknavidrome-systemd.service
+++ b/asknavidrome-systemd.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=AskNavidrome Alexa Skill
+After=network-online.target
+Wants=network-online.target
+
+# USE THIS IF RUNNING BEHIND WIREGUARD
+# After=network-online.target wg-quick@wg0.service
+# Wants=network-online.target
+# Requires=wg-quick@wg0.service
+
+[Service]
+Type=simple
+# UPDATE THIS #
+User=admin
+Group=admin
+WorkingDirectory=/home/asknavidrome/skill
+EnvironmentFile=/home/asknavidrome/skill/.env
+ExecStart=/home/asknavidrome/skill/.venv/bin/gunicorn \
+    -w 1 \
+    --worker-class gthread \
+    --threads 4 \
+    -b 10.10.0.2:5010 \
+    --timeout 30 \
+    --access-logfile - \
+    --error-logfile - \
+    app:app
+
+Restart=on-failure
+RestartSec=5
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+# Hardening (optional but cheap to add)
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/skill/.env
+++ b/skill/.env
@@ -1,0 +1,10 @@
+NAVI_SKILL_ID=amzn1.ask.skill.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+NAVI_SONG_COUNT=50
+NAVI_URL=https://navidrome.yourdomain.com
+NAVI_USER=username
+NAVI_PASS=password
+NAVI_PORT=443
+NAVI_API_PATH=/rest
+NAVI_API_VER=1.16.1
+NAVI_DEBUG=0
+NAVI_FUZZY_THRESHOLD=80

--- a/skill/app.py
+++ b/skill/app.py
@@ -18,9 +18,14 @@ from flask_ask_sdk.skill_adapter import SkillAdapter
 import asknavidrome.subsonic_api as api
 import asknavidrome.media_queue as queue
 import asknavidrome.controller as controller
+from asknavidrome.fuzzy_match import CatalogCache, fuzzy_find_album, fuzzy_find_genre
 
 # Create web service
 app = Flask(__name__)
+
+# ProxyFix to make internal HTTP look like HTTPS
+from werkzeug.middleware.proxy_fix import ProxyFix
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
 # Create skill object
 sb = SkillBuilder()
@@ -45,103 +50,29 @@ logger.addHandler(handler)
 logger.info('AskNavidrome 0.10!')
 logger.debug('Getting configuration from the environment...')
 
-try:
-    if 'NAVI_SKILL_ID' in os.environ:
-        # Set skill ID, this is available on the Alexa Developer Console
-        # if this is not set the web service will respond to any skill.
-        sb.skill_id = os.getenv('NAVI_SKILL_ID')
 
-        logger.info(f'Skill ID set to: {sb.skill_id}')
+def require_env(name: str, log_value: bool = True) -> str:
+    """Fetch a required environment variable or raise NameError."""
 
+    value = os.getenv(name)
+    if value is None:
+        logger.error(f'{name} was not found!')
+        raise NameError(f'{name} is required')
+    if log_value:
+        logger.info(f'{name} is set to: {value}')
     else:
-        raise NameError
-except NameError as err:
-    logger.error(f'The Alexa skill ID was not found! {err}')
-    raise
+        logger.info(f'{name} is set')
+    return value
 
-try:
-    if 'NAVI_SONG_COUNT' in os.environ:
-        min_song_count = os.getenv('NAVI_SONG_COUNT')
 
-        logger.info(f'Minimum song count is set to: {min_song_count}')
-
-    else:
-        raise NameError
-except NameError as err:
-    logger.error(f'The minimum song count was not found! {err}')
-    raise
-
-try:
-    if 'NAVI_URL' in os.environ:
-        navidrome_url = os.getenv('NAVI_URL')
-
-        logger.info(f'The URL for Navidrome is set to: {navidrome_url}')
-
-    else:
-        raise NameError
-except NameError as err:
-    logger.error(f'The URL of the Navidrome server was not found! {err}')
-    raise
-
-try:
-    if 'NAVI_USER' in os.environ:
-        navidrome_user = os.getenv('NAVI_USER')
-
-        logger.info(f'The Navidrome user name is set to: {navidrome_user}')
-
-    else:
-        raise NameError
-except NameError as err:
-    logger.error(f'The Navidrome user name was not found! {err}')
-    raise
-
-try:
-    if 'NAVI_PASS' in os.environ:
-        navidrome_passwd = os.getenv('NAVI_PASS')
-
-        logger.info('The Navidrome password is set')
-
-    else:
-        raise NameError
-except NameError as err:
-    logger.error(f'The Navidrome password was not found! {err}')
-    raise
-
-try:
-    if 'NAVI_PORT' in os.environ:
-        navidrome_port = os.getenv('NAVI_PORT')
-
-        logger.info(f'The Navidrome port is set to: {navidrome_port}')
-
-    else:
-        raise NameError
-except NameError as err:
-    logger.error(f'The Navidrome port was not found! {err}')
-    raise
-
-try:
-    if 'NAVI_API_PATH' in os.environ:
-        navidrome_api_location = os.getenv('NAVI_API_PATH')
-
-        logger.info(f'The Navidrome API path is set to: {navidrome_api_location}')
-
-    else:
-        raise NameError
-except NameError as err:
-    logger.error(f'The Navidrome API path was not found! {err}')
-    raise
-
-try:
-    if 'NAVI_API_VER' in os.environ:
-        navidrome_api_version = os.getenv('NAVI_API_VER')
-
-        logger.info(f'The Navidrome API version is set to: {navidrome_api_version}')
-
-    else:
-        raise NameError
-except NameError as err:
-    logger.error(f'The Navidrome API version was not found! {err}')
-    raise
+sb.skill_id = require_env('NAVI_SKILL_ID')
+min_song_count = require_env('NAVI_SONG_COUNT')
+navidrome_url = require_env('NAVI_URL')
+navidrome_user = require_env('NAVI_USER')
+navidrome_passwd = require_env('NAVI_PASS', log_value=False)
+navidrome_port = require_env('NAVI_PORT')
+navidrome_api_location = require_env('NAVI_API_PATH')
+navidrome_api_version = require_env('NAVI_API_VER')
 
 logger.debug('Configuration has been successfully loaded')
 
@@ -199,8 +130,14 @@ connection = api.SubsonicConnection(navidrome_url,
 try:
     connection.ping()
 
-except:
+except Exception:
     raise RuntimeError('Could not connect to SubSonic API!')
+
+# Fuzzy matching config
+fuzzy_threshold = int(os.getenv('NAVI_FUZZY_THRESHOLD', '70'))
+logger.info(f'Fuzzy match threshold: {fuzzy_threshold}')
+
+catalog = CatalogCache(connection)
 
 logger.info('AskNavidrome Web Service is ready to start!')
 
@@ -308,7 +245,7 @@ class NaviSonicPlayMusicByArtist(AbstractRequestHandler):
         artist = get_slot_value_v2(handler_input, 'artist')
 
         # Search for an artist
-        artist_lookup = connection.search_artist(artist.value)
+        artist_lookup = connection.search_artist_fuzzy(artist.value, catalog, fuzzy_threshold)
 
         if artist_lookup is None:
             text = sanitise_speech_output(f"I couldn't find the artist {artist.value} in the collection.")
@@ -324,9 +261,10 @@ class NaviSonicPlayMusicByArtist(AbstractRequestHandler):
             song_id_list = connection.build_song_list_from_albums(artist_album_lookup, min_song_count)
             play_queue.clear()
 
-            controller.enqueue_songs(connection, play_queue, [song_id_list[0], song_id_list[1]])  # When generating the playlist return the first two tracks.
-            backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))  # Create a thread to enqueue the remaining tracks
-            backgroundProcess.start()  # Start the additional thread
+            controller.enqueue_songs(connection, play_queue, song_id_list[:2])
+            if song_id_list[2:]:
+                backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))
+                backgroundProcess.start()
 
             speech = sanitise_speech_output(f'Playing music by: {artist.value}')
             logger.info(speech)
@@ -368,7 +306,7 @@ class NaviSonicPlayAlbumByArtist(AbstractRequestHandler):
             logger.debug(f'Searching for the album {album.value} by {artist.value}')
 
             # Search for an artist
-            artist_lookup = connection.search_artist(artist.value)
+            artist_lookup = connection.search_artist_fuzzy(artist.value, catalog, fuzzy_threshold)
 
             if artist_lookup is None:
                 text = sanitise_speech_output(f"I couldn't find the artist {artist.value} in the collection.")
@@ -379,24 +317,23 @@ class NaviSonicPlayAlbumByArtist(AbstractRequestHandler):
             else:
                 artist_album_lookup = connection.albums_by_artist(artist_lookup[0].get('id'))
 
-                # Search the list of dictionaries for the requested album
-                # Strings are all converted to lower case to minimise matching errors
-                result = [album_result for album_result in artist_album_lookup if album_result.get('name').lower() == album.value.lower()]
+                matched_album = fuzzy_find_album(artist_album_lookup, album.value, fuzzy_threshold)
 
-                if not result:
+                if not matched_album:
                     text = sanitise_speech_output(f"I couldn't find an album called {album.value} by {artist.value} in the collection.")
                     handler_input.response_builder.speak(text).ask(text)
 
                     return handler_input.response_builder.response
 
                 # At this point we have found an album that matches
-                song_id_list = connection.build_song_list_from_albums(result, -1)
+                song_id_list = connection.build_song_list_from_albums([matched_album], -1)
                 play_queue.clear()
 
                 # Work around the Amazon / Alexa 8 second timeout.
-                controller.enqueue_songs(connection, play_queue, [song_id_list[0], song_id_list[1]])  # When generating the playlist return the first two tracks.
-                backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))  # Create a thread to enqueue the remaining tracks
-                backgroundProcess.start()  # Start the additional thread
+                controller.enqueue_songs(connection, play_queue, song_id_list[:2])
+                if song_id_list[2:]:
+                    backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))
+                    backgroundProcess.start()
 
                 speech = sanitise_speech_output(f'Playing {album.value} by: {artist.value}')
                 logger.info(speech)
@@ -424,9 +361,10 @@ class NaviSonicPlayAlbumByArtist(AbstractRequestHandler):
                 play_queue.clear()
 
                 # Work around the Amazon / Alexa 8 second timeout.
-                controller.enqueue_songs(connection, play_queue, [song_id_list[0], song_id_list[1]])  # When generating the playlist return the first two tracks.
-                backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))  # Create a thread to enqueue the remaining tracks
-                backgroundProcess.start()  # Start the additional thread
+                controller.enqueue_songs(connection, play_queue, song_id_list[:2])
+                if song_id_list[2:]:
+                    backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))
+                    backgroundProcess.start()
 
                 speech = sanitise_speech_output(f'Playing {album.value}')
                 logger.info(speech)
@@ -458,7 +396,7 @@ class NaviSonicPlaySongByArtist(AbstractRequestHandler):
         logger.debug(f'Searching for the song {song.value} by {artist.value}')
 
         # Search for the artist
-        artist_lookup = connection.search_artist(artist.value)
+        artist_lookup = connection.search_artist_fuzzy(artist.value, catalog, fuzzy_threshold)
 
         if artist_lookup is None:
             text = sanitise_speech_output(f"I couldn't find the artist {artist.value} in the collection.")
@@ -517,7 +455,7 @@ class NaviSonicPlayPlaylist(AbstractRequestHandler):
         playlist = get_slot_value_v2(handler_input, 'playlist')
 
         # Search for a playlist
-        playlist_id = connection.search_playlist(playlist.value)
+        playlist_id = connection.search_playlist_fuzzy(playlist.value, fuzzy_threshold)
 
         if playlist_id is None:
             text = sanitise_speech_output("I couldn't find the playlist " + str(playlist.value) + ' in the collection.')
@@ -530,9 +468,10 @@ class NaviSonicPlayPlaylist(AbstractRequestHandler):
             play_queue.clear()
 
             # Work around the Amazon / Alexa 8 second timeout.
-            controller.enqueue_songs(connection, play_queue, [song_id_list[0], song_id_list[1]])  # When generating the playlist return the first two tracks.
-            backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))  # Create a thread to enqueue the remaining tracks
-            backgroundProcess.start()  # Start the additional thread
+            controller.enqueue_songs(connection, play_queue, song_id_list[:2])
+            if song_id_list[2:]:
+                backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))
+                backgroundProcess.start()
 
             speech = sanitise_speech_output('Playing playlist ' + str(playlist.value))
             logger.info(speech)
@@ -566,7 +505,11 @@ class NaviSonicPlayMusicByGenre(AbstractRequestHandler):
         # Get the requested genre
         genre = get_slot_value_v2(handler_input, 'genre')
 
-        song_id_list = connection.build_song_list_from_genre(genre.value, min_song_count)
+        # Try to resolve genre, falling back to fuzzy match
+        resolved_genre = fuzzy_find_genre(catalog, genre.value, fuzzy_threshold)
+        genre_to_search = resolved_genre if resolved_genre else genre.value
+
+        song_id_list = connection.build_song_list_from_genre(genre_to_search, min_song_count)
 
         if song_id_list is None:
             text = sanitise_speech_output(f"I couldn't find any {genre.value} songs in the collection.")
@@ -579,9 +522,10 @@ class NaviSonicPlayMusicByGenre(AbstractRequestHandler):
             play_queue.clear()
 
             # Work around the Amazon / Alexa 8 second timeout.
-            controller.enqueue_songs(connection, play_queue, [song_id_list[0], song_id_list[1]])  # When generating the playlist return the first two tracks.
-            backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))  # Create a thread to enqueue the remaining tracks
-            backgroundProcess.start()  # Start the additional thread
+            controller.enqueue_songs(connection, play_queue, song_id_list[:2])
+            if song_id_list[2:]:
+                backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))
+                backgroundProcess.start()
 
             speech = sanitise_speech_output(f'Playing {genre.value} music')
             logger.info(speech)
@@ -625,9 +569,10 @@ class NaviSonicPlayMusicRandom(AbstractRequestHandler):
             play_queue.clear()
 
             # Work around the Amazon / Alexa 8 second timeout.
-            controller.enqueue_songs(connection, play_queue, [song_id_list[0], song_id_list[1]])  # When generating the playlist return the first two tracks.
-            backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))  # Create a thread to enqueue the remaining tracks
-            backgroundProcess.start()  # Start the additional thread
+            controller.enqueue_songs(connection, play_queue, song_id_list[:2])
+            if song_id_list[2:]:
+                backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))
+                backgroundProcess.start()
 
             speech = sanitise_speech_output('Playing random music')
             logger.info(speech)
@@ -671,9 +616,10 @@ class NaviSonicPlayFavouriteSongs(AbstractRequestHandler):
             play_queue.clear()
 
             # Work around the Amazon / Alexa 8 second timeout.
-            controller.enqueue_songs(connection, play_queue, [song_id_list[0], song_id_list[1]])  # When generating the playlist return the first two tracks.
-            backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))  # Create a thread to enqueue the remaining tracks
-            backgroundProcess.start()  # Start the additional thread
+            controller.enqueue_songs(connection, play_queue, song_id_list[:2])
+            if song_id_list[2:]:
+                backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))
+                backgroundProcess.start()
 
             speech = sanitise_speech_output('Playing your favourite tracks.')
             logger.info(speech)
@@ -762,10 +708,186 @@ class NaviSonicUnstarSong(AbstractRequestHandler):
         current_track = play_queue.get_current_track()
 
         song_id = current_track.id
-        connection.star_entry(song_id, 'song')
         connection.unstar_entry(song_id, 'song')
 
         return handler_input.response_builder.response
+
+class NaviSonicPlay(AbstractRequestHandler):
+    """Handle NaviSonicPlay - generic free-form play intent
+
+    Receives a raw search query from AMAZON.SearchQuery and resolves it
+    server-side against artists, albums, songs, and playlists using
+    fuzzy matching.
+    """
+
+    def can_handle(self, handler_input: HandlerInput) -> bool:
+        return is_intent_name('NaviSonicPlay')(handler_input)
+
+    def handle(self, handler_input: HandlerInput) -> Response:
+        global backgroundProcess
+        logger.debug('In NaviSonicPlay')
+
+        if backgroundProcess is not None:
+            backgroundProcess.terminate()
+            backgroundProcess.join()
+
+        query_slot = get_slot_value_v2(handler_input, 'query')
+        query = query_slot.value if query_slot else ''
+        logger.info(f'Generic play query: "{query}"')
+
+        if not query:
+            text = sanitise_speech_output("I didn't catch what you want to play.")
+            handler_input.response_builder.speak(text).ask(text)
+            return handler_input.response_builder.response
+
+        return self._resolve_and_play(query, handler_input)
+
+    def _resolve_and_play(self, query: str, handler_input: HandlerInput) -> Response:
+        global backgroundProcess
+
+        # Check for "by" to split into item + artist
+        query_lower = query.lower()
+        if ' by ' in query_lower:
+            parts = query.split(' by ', 1)
+            item_part = parts[0].strip()
+            artist_part = parts[1].strip()
+
+            if item_part and artist_part:
+                result = self._try_item_by_artist(item_part, artist_part, handler_input)
+                if result is not None:
+                    return result
+
+        # Try as artist
+        result = self._try_artist(query, handler_input)
+        if result is not None:
+            return result
+
+        # Try as album
+        result = self._try_album(query, handler_input)
+        if result is not None:
+            return result
+
+        # Try as song
+        result = self._try_song(query, handler_input)
+        if result is not None:
+            return result
+
+        # Try as playlist
+        result = self._try_playlist(query, handler_input)
+        if result is not None:
+            return result
+
+        # Nothing matched
+        text = sanitise_speech_output(f"I couldn't find anything matching {query} in the collection.")
+        handler_input.response_builder.speak(text).ask(text)
+        return handler_input.response_builder.response
+
+    def _try_item_by_artist(self, item: str, artist_name: str, handler_input: HandlerInput) -> Response:
+        global backgroundProcess
+
+        artist_lookup = connection.search_artist_fuzzy(artist_name, catalog, fuzzy_threshold)
+        if artist_lookup is None:
+            return None
+
+        artist_id = artist_lookup[0].get('id')
+        artist_album_lookup = connection.albums_by_artist(artist_id)
+
+        # Try as album by artist
+        matched_album = fuzzy_find_album(artist_album_lookup, item, fuzzy_threshold)
+        if matched_album:
+            song_id_list = connection.build_song_list_from_albums([matched_album], -1)
+            if song_id_list:
+                return self._start_playing(song_id_list, f'Playing {item} by {artist_name}', handler_input)
+
+        # Try as song by artist
+        song_list = connection.search_song(item)
+        if song_list:
+            song_dets = [s.get('id') for s in song_list if s.get('artistId') == artist_id]
+            if song_dets:
+                play_queue.clear()
+                controller.enqueue_songs(connection, play_queue, song_dets)
+                speech = sanitise_speech_output(f'Playing {item} by {artist_name}')
+                logger.info(speech)
+                card = {'title': 'AskNavidrome', 'text': speech}
+                track_details = play_queue.get_next_track()
+                return controller.start_playback('play', speech, card, track_details, handler_input)
+
+        return None
+
+    def _try_artist(self, query: str, handler_input: HandlerInput) -> Response:
+        global backgroundProcess
+
+        artist_lookup = connection.search_artist_fuzzy(query, catalog, fuzzy_threshold)
+        if artist_lookup is None:
+            return None
+
+        artist_album_lookup = connection.albums_by_artist(artist_lookup[0].get('id'))
+        song_id_list = connection.build_song_list_from_albums(artist_album_lookup, min_song_count)
+        if not song_id_list:
+            return None
+
+        return self._start_playing(song_id_list, f'Playing music by {query}', handler_input, shuffle=True)
+
+    def _try_album(self, query: str, handler_input: HandlerInput) -> Response:
+        global backgroundProcess
+
+        result = connection.search_album(query)
+        if result is None:
+            # Try fuzzy against all albums from all artists in catalog
+            return None
+
+        song_id_list = connection.build_song_list_from_albums(result, -1)
+        if not song_id_list:
+            return None
+
+        return self._start_playing(song_id_list, f'Playing {query}', handler_input)
+
+    def _try_song(self, query: str, handler_input: HandlerInput) -> Response:
+        song_list = connection.search_song(query)
+        if not song_list:
+            return None
+
+        song_dets = [s.get('id') for s in song_list]
+        play_queue.clear()
+        controller.enqueue_songs(connection, play_queue, song_dets)
+
+        speech = sanitise_speech_output(f'Playing {query}')
+        logger.info(speech)
+        card = {'title': 'AskNavidrome', 'text': speech}
+        track_details = play_queue.get_next_track()
+        return controller.start_playback('play', speech, card, track_details, handler_input)
+
+    def _try_playlist(self, query: str, handler_input: HandlerInput) -> Response:
+        global backgroundProcess
+
+        playlist_id = connection.search_playlist_fuzzy(query, fuzzy_threshold)
+        if playlist_id is None:
+            return None
+
+        song_id_list = connection.build_song_list_from_playlist(playlist_id)
+        if not song_id_list:
+            return None
+
+        return self._start_playing(song_id_list, f'Playing playlist {query}', handler_input)
+
+    def _start_playing(self, song_id_list: list, speech_text: str, handler_input: HandlerInput, shuffle: bool = False) -> Response:
+        global backgroundProcess
+
+        play_queue.clear()
+        controller.enqueue_songs(connection, play_queue, song_id_list[:2])
+        if song_id_list[2:]:
+            backgroundProcess = Process(target=queue_worker_thread, args=(connection, play_queue, song_id_list[2:]))
+            backgroundProcess.start()
+
+        if shuffle:
+            play_queue.shuffle()
+
+        speech = sanitise_speech_output(speech_text)
+        logger.info(speech)
+        card = {'title': 'AskNavidrome', 'text': speech}
+        track_details = play_queue.get_next_track()
+        return controller.start_playback('play', speech, card, track_details, handler_input)
+
 
 #
 # AudioPlayer Handlers
@@ -826,6 +948,10 @@ class PlaybackNearlyFinishedHandler(AbstractRequestHandler):
         logger.info('Queuing next track...')
         track_details = play_queue.enqueue_next_track()
 
+        if track_details is None:
+            logger.info('No more tracks to enqueue, end of playlist')
+            return handler_input.response_builder.response
+
         return controller.start_playback('continue', None, None, track_details, handler_input)
 
 
@@ -842,10 +968,11 @@ class PlaybackFinishedHandler(AbstractRequestHandler):
     def handle(self, handler_input: HandlerInput) -> Response:
         logger.debug('In PlaybackFinishedHandler')
 
-        # Generate a timestamp in milliseconds for scrobbling
-        timestamp_ms = datetime.now().timestamp()
+        # Generate a timestamp for scrobbling
+        # py-sonic's scrobble() converts to milliseconds internally via _ts2milli()
+        listen_time = datetime.now().timestamp()
         current_track = play_queue.get_current_track()
-        connection.scrobble(current_track.id, timestamp_ms)
+        connection.scrobble(current_track.id, listen_time)
         play_queue.get_next_track()
 
         return handler_input.response_builder.response
@@ -1118,6 +1245,7 @@ sb.add_request_handler(NaviSonicRandomiseQueue())
 sb.add_request_handler(NaviSonicSongDetails())
 sb.add_request_handler(NaviSonicStarSong())
 sb.add_request_handler(NaviSonicUnstarSong())
+sb.add_request_handler(NaviSonicPlay())
 
 # Register AutoPlayer Handlers
 sb.add_request_handler(PlaybackStartedHandler())

--- a/skill/asknavidrome/controller.py
+++ b/skill/asknavidrome/controller.py
@@ -184,24 +184,30 @@ def enqueue_songs(api: SubsonicConnection, queue: MediaQueue, song_id_list: list
     """
 
     for song_id in song_id_list:
-        song_details = api.get_song_details(song_id)
-        song_uri = api.get_song_uri(song_id)
+        try:
+            song_details = api.get_song_details(song_id)
+            song_uri = api.get_song_uri(song_id)
 
-        # Create track object from song details
-        new_track = Track(song_details.get('song').get('id'),
-                          song_details.get('song').get('title'),
-                          song_details.get('song').get('artist'),
-                          song_details.get('song').get('artistId'),
-                          song_details.get('song').get('album'),
-                          song_details.get('song').get('albumId'),
-                          song_details.get('song').get('track'),
-                          song_details.get('song').get('year'),
-                          song_details.get('song').get('genre'),
-                          song_details.get('song').get('duration'),
-                          song_details.get('song').get('bitRate'),
-                          song_uri,
-                          0,
-                          None)
+            song = song_details.get('song', {})
 
-        # Add track object to queue
-        queue.add_track(new_track)
+            # Create track object from song details
+            new_track = Track(song.get('id'),
+                              song.get('title'),
+                              song.get('artist'),
+                              song.get('artistId'),
+                              song.get('album'),
+                              song.get('albumId'),
+                              song.get('track'),
+                              song.get('year'),
+                              song.get('genre'),
+                              song.get('duration'),
+                              song.get('bitRate'),
+                              song_uri,
+                              0,
+                              None)
+
+            # Add track object to queue
+            queue.add_track(new_track)
+        except Exception:
+            logger.error(f'Failed to enqueue song {song_id}, skipping', exc_info=True)
+            continue

--- a/skill/asknavidrome/fuzzy_match.py
+++ b/skill/asknavidrome/fuzzy_match.py
@@ -1,0 +1,168 @@
+import logging
+from typing import Union
+
+from rapidfuzz import fuzz, process
+
+
+logger = logging.getLogger(__name__)
+
+
+class CatalogCache:
+    """Lazily fetches and caches artist and genre lists from the Subsonic server."""
+
+    def __init__(self, connection) -> None:
+        self._connection = connection
+        self._artists = None
+        self._genres = None
+
+    def get_artists(self) -> list:
+        if self._artists is None:
+            self._artists = self._fetch_all_artists()
+        return self._artists
+
+    def get_genres(self) -> list:
+        if self._genres is None:
+            self._genres = self._fetch_all_genres()
+        return self._genres
+
+    def refresh(self) -> None:
+        self._artists = None
+        self._genres = None
+
+    def _fetch_all_artists(self) -> list:
+        """Flatten the alphabetical index structure from getArtists() into a simple list."""
+        try:
+            response = self._connection.conn.getArtists()
+            index_list = response.get('artists', {}).get('index', [])
+
+            artists = []
+            for index in index_list:
+                for artist in index.get('artist', []):
+                    artists.append({'id': artist.get('id'), 'name': artist.get('name', '')})
+
+            logger.debug(f'Cached {len(artists)} artists from server')
+            return artists
+        except Exception:
+            logger.error('Failed to fetch artist catalog', exc_info=True)
+            return []
+
+    def _fetch_all_genres(self) -> list:
+        """Fetch the genre list from the server."""
+        try:
+            response = self._connection.conn.getGenres()
+            genre_list = response.get('genres', {}).get('genre', [])
+
+            genres = [g.get('value', '') for g in genre_list if g.get('value')]
+            logger.debug(f'Cached {len(genres)} genres from server')
+            return genres
+        except Exception:
+            logger.error('Failed to fetch genre catalog', exc_info=True)
+            return []
+
+
+def fuzzy_find_artist(catalog: CatalogCache, query: str, threshold: int = 70) -> Union[dict, None]:
+    """Find the best matching artist from the cached catalog.
+
+    :param catalog: A CatalogCache instance
+    :param query: The artist name to search for
+    :param threshold: Minimum score (0-100) to accept a match
+    :return: The matched artist dict {id, name} or None
+    """
+    artists = catalog.get_artists()
+    if not artists:
+        return None
+
+    choices = {artist['name']: artist for artist in artists if artist.get('name')}
+
+    result = process.extractOne(
+        query, choices.keys(), scorer=fuzz.token_sort_ratio, score_cutoff=threshold
+    )
+
+    if result is None:
+        logger.debug(f'Fuzzy artist search: no match for "{query}" above threshold {threshold}')
+        return None
+
+    matched_name, score, _ = result
+    logger.info(f'Fuzzy artist match: "{query}" → "{matched_name}" (score: {score})')
+    return choices[matched_name]
+
+
+def fuzzy_find_album(albums: list, query: str, threshold: int = 70) -> Union[dict, None]:
+    """Find the best matching album from a list of album dicts.
+
+    :param albums: A list of album dicts (each must have a 'name' key)
+    :param query: The album name to search for
+    :param threshold: Minimum score (0-100) to accept a match
+    :return: The matched album dict or None
+    """
+    if not albums:
+        return None
+
+    choices = {album.get('name', ''): album for album in albums if album.get('name')}
+
+    result = process.extractOne(
+        query, choices.keys(), scorer=fuzz.token_sort_ratio, score_cutoff=threshold
+    )
+
+    if result is None:
+        logger.debug(f'Fuzzy album search: no match for "{query}" above threshold {threshold}')
+        return None
+
+    matched_name, score, _ = result
+    logger.info(f'Fuzzy album match: "{query}" → "{matched_name}" (score: {score})')
+    return choices[matched_name]
+
+
+def fuzzy_find_genre(catalog: CatalogCache, query: str, threshold: int = 70) -> Union[str, None]:
+    """Find the best matching genre from the cached catalog.
+
+    :param catalog: A CatalogCache instance
+    :param query: The genre name to search for
+    :param threshold: Minimum score (0-100) to accept a match
+    :return: The matched genre string or None
+    """
+    genres = catalog.get_genres()
+    if not genres:
+        return None
+
+    result = process.extractOne(
+        query, genres, scorer=fuzz.token_sort_ratio, score_cutoff=threshold
+    )
+
+    if result is None:
+        logger.debug(f'Fuzzy genre search: no match for "{query}" above threshold {threshold}')
+        return None
+
+    matched_name, score, _ = result
+    logger.info(f'Fuzzy genre match: "{query}" → "{matched_name}" (score: {score})')
+    return matched_name
+
+
+def fuzzy_find_playlist(playlists: list, query: str, threshold: int = 70) -> Union[str, None]:
+    """Find the best matching playlist from a list of playlist dicts.
+
+    :param playlists: A list of playlist dicts (each must have 'id' and 'name' keys)
+    :param query: The playlist name to search for
+    :param threshold: Minimum score (0-100) to accept a match
+    :return: The matched playlist ID or None
+    """
+    if not playlists:
+        return None
+
+    choices = {}
+    for pl in playlists:
+        name = pl.get('name', '')
+        if name:
+            choices[name] = pl.get('id')
+
+    result = process.extractOne(
+        query, choices.keys(), scorer=fuzz.token_sort_ratio, score_cutoff=threshold
+    )
+
+    if result is None:
+        logger.debug(f'Fuzzy playlist search: no match for "{query}" above threshold {threshold}')
+        return None
+
+    matched_name, score, _ = result
+    logger.info(f'Fuzzy playlist match: "{query}" → "{matched_name}" (score: {score})')
+    return choices[matched_name]

--- a/skill/asknavidrome/media_queue.py
+++ b/skill/asknavidrome/media_queue.py
@@ -169,11 +169,15 @@ class MediaQueue:
 
         Get the next track from self.queue and add it to the history deque
 
-        :return: The next track object
+        :return: The next track object, or the current track if the queue is empty
         :rtype: Track
         """
 
         self.logger.debug('In get_next_track()')
+
+        if not self.queue:
+            self.logger.debug('Queue is empty, returning current track')
+            return self.current_track
 
         if self.current_track.id == '' or self.current_track.id is None:
             # This is the first track
@@ -194,11 +198,15 @@ class MediaQueue:
         Get the last track added to the history deque and
         add it to the front of the play queue
 
-        :return: The previous track object
+        :return: The previous track object, or the current track if history is empty
         :rtype: Track
         """
 
         self.logger.debug('In get_previous_track()')
+
+        if not self.history:
+            self.logger.debug('History is empty, returning current track')
+            return self.current_track
 
         # Return the current track to the queue
         self.queue.appendleft(self.current_track)
@@ -211,18 +219,22 @@ class MediaQueue:
 
         return self.current_track
 
-    def enqueue_next_track(self) -> Track:
+    def enqueue_next_track(self):
         """Get the next buffered track
 
         Get the next track from the buffer without updating the current track
         attribute.  This allows Amazon to send the PlaybackNearlyFinished
         request early to queue the next track while maintaining the playlist
 
-        :return: The next track to be played
-        :rtype: Track
+        :return: The next track to be played, or None if the buffer is empty
+        :rtype: Track | None
         """
 
         self.logger.debug('In enqueue_next_track()')
+
+        if not self.buffer:
+            self.logger.debug('Buffer is empty, no more tracks to enqueue')
+            return None
 
         return self.buffer.popleft()
 
@@ -236,6 +248,7 @@ class MediaQueue:
         self.queue.clear()
         self.history.clear()
         self.buffer.clear()
+        self.current_track = Track()
 
     def get_queue_count(self) -> int:
         """Get the number of tracks in the queue

--- a/skill/asknavidrome/subsonic_api.py
+++ b/skill/asknavidrome/subsonic_api.py
@@ -6,6 +6,8 @@ import secrets
 
 import libsonic
 
+from .fuzzy_match import CatalogCache, fuzzy_find_artist, fuzzy_find_playlist
+
 
 class SubsonicConnection:
     """Class with methods to interact with Subsonic API compatible media servers
@@ -102,7 +104,8 @@ class SubsonicConnection:
         playlist_dict = self.conn.getPlaylists()
 
         # Search the list of dictionaries for a playlist with a name that matches the search term
-        playlist_id_list = [item.get('id') for item in playlist_dict['playlists']['playlist'] if item.get('name').lower() == term.lower()]
+        playlist_id_list = [item.get('id') for item in playlist_dict.get('playlists', {}).get('playlist', [])
+                            if (item.get('name') or '').lower() == term.lower()]
 
         if len(playlist_id_list) == 1:
             # We have matched the playlist return it
@@ -133,15 +136,11 @@ class SubsonicConnection:
 
         result_dict = self.conn.search3(term)
 
-        if len(result_dict['searchResult3']) > 0:
-            # Results found
-            result_count = len(result_dict['searchResult3']['artist'])
+        results = result_dict.get('searchResult3', {}).get('artist', [])
 
-            self.logger.debug(f'Searching artists for term: {term} found {result_count} entries.')
-
-            if result_count > 0:
-                # Results were found
-                return result_dict['searchResult3']['artist']
+        if results:
+            self.logger.debug(f'Searching artists for term: {term} found {len(results)} entries.')
+            return results
 
         # No results were found
         return None
@@ -158,15 +157,11 @@ class SubsonicConnection:
 
         result_dict = self.conn.search3(term)
 
-        if len(result_dict['searchResult3']) > 0:
-            # Results found
-            result_count = len(result_dict['searchResult3']['album'])
+        results = result_dict.get('searchResult3', {}).get('album', [])
 
-            self.logger.debug(f'Searching albums for term: {term} found {result_count} entries.')
-
-            if result_count > 0:
-                # Results were found
-                return result_dict['searchResult3']['album']
+        if results:
+            self.logger.debug(f'Searching albums for term: {term} found {len(results)} entries.')
+            return results
 
         # No results were found
         return None
@@ -183,18 +178,64 @@ class SubsonicConnection:
 
         result_dict = self.conn.search3(term)
 
-        if len(result_dict['searchResult3']) > 0:
-            # Results found
-            result_count = len(result_dict['searchResult3']['song'])
+        results = result_dict.get('searchResult3', {}).get('song', [])
 
-            self.logger.debug(f'Searching songs for term: {term}, found {result_count} entries.')
-
-            if result_count > 0:
-                # Results were found
-                return result_dict['searchResult3']['song']
+        if results:
+            self.logger.debug(f'Searching songs for term: {term}, found {len(results)} entries.')
+            return results
 
         # No results were found
         return None
+
+    def search_artist_fuzzy(self, term: str, catalog: CatalogCache, threshold: int = 70) -> Union[dict, None]:
+        """Search for an artist with fuzzy fallback.
+
+        Tries server-side search first, falls back to fuzzy matching against
+        the full artist catalog if no results are found.
+
+        :param str term: The name of the artist
+        :param CatalogCache catalog: A CatalogCache instance for fuzzy fallback
+        :param int threshold: Minimum fuzzy match score (0-100)
+        :return: A list containing the matched artist dict, or None
+        :rtype: list | None
+        """
+
+        self.logger.debug('In function search_artist_fuzzy()')
+
+        result = self.search_artist(term)
+        if result is not None:
+            return result
+
+        self.logger.debug(f'Server search found no artist for "{term}", trying fuzzy match')
+        matched = fuzzy_find_artist(catalog, term, threshold)
+        if matched is None:
+            return None
+
+        return [matched]
+
+    def search_playlist_fuzzy(self, term: str, threshold: int = 70) -> Union[str, None]:
+        """Search for a playlist with fuzzy fallback.
+
+        Tries exact match first, falls back to fuzzy matching against
+        all playlists if no results are found.
+
+        :param str term: The name of the playlist
+        :param int threshold: Minimum fuzzy match score (0-100)
+        :return: The playlist ID or None
+        :rtype: str | None
+        """
+
+        self.logger.debug('In function search_playlist_fuzzy()')
+
+        result = self.search_playlist(term)
+        if result is not None:
+            return result
+
+        self.logger.debug(f'Exact playlist match failed for "{term}", trying fuzzy match')
+        playlist_dict = self.conn.getPlaylists()
+        playlists = playlist_dict.get('playlists', {}).get('playlist', [])
+
+        return fuzzy_find_playlist(playlists, term, threshold)
 
     def albums_by_artist(self, id: str) -> 'list[dict]':
         """Get the albums for a given artist
@@ -270,7 +311,7 @@ class SubsonicConnection:
         song_id_list = []
         playlist_details = self.conn.getPlaylist(id)
 
-        song_id_list = [song_detail.get('id') for song_detail in playlist_details.get('playlist').get('entry')]
+        song_id_list = [song_detail.get('id') for song_detail in playlist_details.get('playlist', {}).get('entry', [])]
 
         return song_id_list
 
@@ -283,9 +324,9 @@ class SubsonicConnection:
 
         self.logger.debug('In function build_song_list_from_favourites()')
 
-        favourite_songs = self.conn.getStarred2().get('starred2').get('song')
+        favourite_songs = self.conn.getStarred2().get('starred2', {}).get('song')
 
-        if len(favourite_songs) > 0:
+        if favourite_songs:
             song_id_list = [song.get('id') for song in favourite_songs]
 
             return song_id_list
@@ -304,12 +345,11 @@ class SubsonicConnection:
 
         self.logger.debug('In function build_song_list_from_genre()')
 
-        # Note the use of title() to capitalise the first letter of each word in the genre
-        # without this the genres do not match the strings returned by the API.
-        self.logger.debug(f'Searching for {genre.title()} music')
-        songs_from_genre = self.conn.getSongsByGenre(genre.title(), count).get('songsByGenre').get('song')
+        genre_name = self._resolve_genre_name(genre)
+        self.logger.debug(f'Searching for {genre_name} music')
+        songs_from_genre = self.conn.getSongsByGenre(genre_name, count).get('songsByGenre', {}).get('song')
 
-        if len(songs_from_genre) > 0:
+        if songs_from_genre:
             song_id_list = [song.get('id') for song in songs_from_genre]
 
             return song_id_list
@@ -326,15 +366,41 @@ class SubsonicConnection:
         """
 
         self.logger.debug('In function build_random_song_list()')
-        random_songs = self.conn.getRandomSongs(count).get('randomSongs').get('song')
+        random_songs = self.conn.getRandomSongs(count).get('randomSongs', {}).get('song')
 
-        if len(random_songs) > 0:
+        if random_songs:
             song_id_list = [song.get('id') for song in random_songs]
 
             return song_id_list
 
         else:
             return None
+
+    def _resolve_genre_name(self, genre: str) -> str:
+        """Resolve a genre string to the server's canonical genre name.
+
+        Fetches the genre list from the server and does a case-insensitive match.
+        Falls back to .title() if no match is found.
+
+        :param str genre: The genre name from the user
+        :return: The canonical genre name
+        :rtype: str
+        """
+
+        try:
+            genres_response = self.conn.getGenres()
+            genre_list = genres_response.get('genres', {}).get('genre', [])
+
+            for g in genre_list:
+                name = g.get('value', '')
+                if name.lower() == genre.lower():
+                    self.logger.debug(f'Resolved genre "{genre}" to server genre "{name}"')
+                    return name
+        except Exception:
+            self.logger.error(f'Failed to fetch genres from server', exc_info=True)
+
+        self.logger.debug(f'No exact genre match for "{genre}", falling back to title case')
+        return genre.title()
 
     def get_song_details(self, id: str) -> dict:
         """Get details about a given song ID

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "skill"
+version = "0.1.0"
+description = "AskNavidrome Alexa Skill"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "ask-sdk>=1.19.0",
+    "autodocsumm>=0.2.15",
+    "flake8>=7.3.0",
+    "flask-ask-sdk>=1.0.0",
+    "gunicorn>=26.0.0",
+    "oscrypto",
+    "py-sonic>=1.1.2",
+    "rapidfuzz>=3.0.0",
+    "rinohtype>=0.5.6",
+    "sphinx>=9.0.4",
+    "sphinx-book-theme>=1.2.0",
+]
+
+[tool.uv.sources]
+oscrypto = { git = "https://github.com/wbond/oscrypto.git", rev = "d5f3437" }


### PR DESCRIPTION
Hi @rosskouk, thanks for creating this project! It was really easy to set up on my personal server.

I struggled with requesting "Play _music by_ {artist}" or "Play _the song_ {song}" because I have gotten used to simply saying "Play {artist}" or "Play {song} by {artist}". This is typically how Apple Music, Spotify or Amazon Music work with the Alexa.

So I used Claude to create a generic "Play {query}" intent for AskNavidrome. This allows the server to resolve the query suitably following this logic:

1. If query contains "by" → tries album-by-artist, then song-by-artist
2. Tries as artist (fuzzy match against full catalog)
3. Tries as album (server search)
4. Tries as song (server search)
5. Tries as playlist (fuzzy match)
6. If nothing matches → speaks "I couldn't find anything matching..."

The user can now make requests like:

- "Play {album} by {artist}"
- "Play {song} by {artist}"
- "Play {artist}"
- "Play {album}"
- "Play {song}"
- "Play {playlist}"

To implement this, a fuzzy matching script ([`fuzzy_match.py`](https://github.com/gsidhu/asknavidrome/blob/main/skill/asknavidrome/fuzzy_match.py)) is added with a dependency ([rapidfuzz](https://pypi.org/project/RapidFuzz/)). This also adds a new environment variable called `NAVI_FUZZY_THRESHOLD` for the fuzziness threshold (0-100) to use (default: 70).

Changes made:

1. Since I run this project on my Raspberry Pi 5 (Debian 12), I had to pin to a specific branch of the [oscrypto](https://github.com/wbond/oscrypto.git) package to get `libcrypto` working. You can see it in the [pyproject.toml](https://github.com/gsidhu/asknavidrome/blob/main/skill/pyproject.toml).
2. I have also added an environment file ([`.env`](https://github.com/gsidhu/asknavidrome/blob/main/skill/.env)) in the `skill` directory and updated the `app.py` script ([L54-75](https://github.com/gsidhu/asknavidrome/blob/03c8c6c8abfad785b5d2343458fc59907ee502ce/skill/app.py#L54)) to load the environment variables using a single function. 
3. Added a sample [`systemd` service file](https://github.com/gsidhu/asknavidrome/blob/main/asknavidrome-systemd.service) for users wanting to run the Flask server with Gunicorn, and optionally, a WireGuard connection.
4. Since the Flask app sits behind a proxy, requests might look like they're coming from localhost over plain HTTP internally, even though the real client connected over HTTPS. Some signature/URL validation in ask-sdk can be sensitive to this. This is fixed by wrapping the Flask app with Werkzeug's ProxyFix middleware ([L26-28](https://github.com/gsidhu/asknavidrome/blob/03c8c6c8abfad785b5d2343458fc59907ee502ce/skill/app.py#L26)).
5. A few robustness fixes to prevent crashes caused by empty deque guards, list slicing and `.get` chaining – identified and fixed by Claude Opus 4.6.

With these updates this Alexa Skill is a near one-to-one replacement of Apple Music/Spotify for me. Thanks to you!

I hope you'd like to merge this PR with the core repo!

Cheers,
Gurjot

PS: I am not sure how to update the sphinx documentation, so haven't touched that.